### PR TITLE
fix: rent_pay didn't reset rent value

### DIFF
--- a/budgetpet/application.py
+++ b/budgetpet/application.py
@@ -142,33 +142,34 @@ def check_day_of_monthly_events(events: list[dict]) -> list:
 
         if last_executed.year != today.year or last_executed.month != today.month:
             events_to_run.append(event['id'])
-    
     return events_to_run
 
 
 def run_monthly_event(events_to_run: list) -> None:
-    if events_to_run == 1:
-        pay_rent(events_to_run)
-    elif events_to_run == 2:
-        monthly_recalculations(events_to_run)
+    if 1 in events_to_run:
+        pay_rent(1)
+    elif 2 in events_to_run:
+        monthly_recalculations(2)
 
 
 def should_run_monthly_event() -> None:
+    logger.info("Проверка ежемесячных ивентов...")
     try:
         events_data = get_monthly_events()
         events_to_run = check_day_of_monthly_events(events_data)
         if events_to_run:
             run_monthly_event(events_to_run)
+            logger.info("Ивент запущен, номер: %s", events_to_run)
     except Exception as e:
         logger.error('Ошибка при проверке ежемесячных ивентов: %s', e)
         raise
 
 
-def pay_rent(event_id) -> None:
+def pay_rent(event_id: int) -> None:
     try:
         with db_cursor() as cursor:
             current_balance = get_current_budget_state(cursor)
-            updated_state = current_balance.model_copy(update={'operation_rent': Decimal('0')})
+            updated_state = current_balance.model_copy(update={'rent': Decimal('0')})
             save_budget_state(updated_state, cursor)
 
             last_executed_update = date.today()

--- a/budgetpet/logger.py
+++ b/budgetpet/logger.py
@@ -1,10 +1,11 @@
 import logging
+from logging.handlers import RotatingFileHandler
 
 logger = logging.getLogger("budgetpet")
 logger.setLevel(logging.DEBUG)
 
 if not logger.handlers:
-    handler = logging.FileHandler("debug.log", mode='a', encoding='utf-8')
+    handler = RotatingFileHandler('debug.log', maxBytes=1024*1024, backupCount=3, encoding='utf-8')
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/budgetpet/web_api.py
+++ b/budgetpet/web_api.py
@@ -89,8 +89,7 @@ def statistics():
     return render_template('statistics.html')
 
 
-should_run_monthly_event()
-
 
 if __name__ == '__main__':
+    should_run_monthly_event()
     app.run(debug=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,76 @@
+from budgetpet.logger import logger
+from unittest.mock import patch, MagicMock
+from budgetpet.application import should_run_monthly_event, pay_rent
+from budgetpet.models import BudgetState
+from decimal import Decimal
+from datetime import date
+
+
+def test_should_run_monthly_event_runs_events() -> None:
+    '''Check if monthly events runs at all'''
+    fake_events = [
+        {"id": 1, "trigger_day": 29, "last_executed": None},
+        {"id": 2, "trigger_day": 1, "last_executed": None}
+    ]
+
+    #what events we want to run
+    fake_events_to_run = [1, 2]
+
+    with patch("budgetpet.application.get_monthly_events", return_value=fake_events) as mock_get_events, \
+        patch("budgetpet.application.check_day_of_monthly_events", return_value=fake_events_to_run) as mock_check_day_of_monthly_events, \
+        patch("budgetpet.application.run_monthly_event") as mock_run_events:
+
+        should_run_monthly_event()
+
+        mock_get_events.assert_called_once()
+        mock_check_day_of_monthly_events.assert_called_once_with(fake_events)
+        mock_run_events.assert_called_once_with(fake_events_to_run)
+
+
+def test_should_run_monthly_event_no_events_to_run():
+    '''Check if no events run, if they should not'''
+    with patch("budgetpet.application.get_monthly_events", return_value=[]) as mock_get_events, \
+         patch("budgetpet.application.check_day_of_monthly_events", return_value=[]) as mock_check_events, \
+         patch("budgetpet.application.run_monthly_event") as mock_run_events:
+
+        should_run_monthly_event()
+
+        mock_get_events.assert_called_once()
+        mock_check_events.assert_called_once_with([])
+        mock_run_events.assert_not_called()
+
+
+def test_pay_rent() -> None:
+    '''Test that rent pay really become 0'''
+
+    fake_balance = BudgetState(
+        reserve=Decimal("1000"),
+        available_funds=Decimal("1000"),
+        rent=Decimal("810"),
+        taxes=Decimal("1000")
+    )
+    fake_id = 1
+    fake_today = date(2025, 7, 1)
+
+    mock_cursor = MagicMock()
+    with patch("budgetpet.application.db_cursor") as mock_db_cursor, \
+        patch("budgetpet.application.get_current_budget_state", return_value=fake_balance) as mock_get_current_budget_state, \
+        patch("budgetpet.application.save_budget_state") as mock_save_budget_state, \
+        patch("budgetpet.application.date") as mock_date, \
+        patch("budgetpet.application.update_monthly_event") as mock_update_monthly_event:
+
+        mock_cm = MagicMock() #context manager
+        mock_cm.__enter__.return_value = mock_cursor
+        mock_db_cursor.return_value = mock_cm #mock db_cursor call
+
+        mock_date.today.return_value = fake_today
+        
+        pay_rent(fake_id)
+
+        mock_get_current_budget_state.assert_called_once_with(mock_cursor)
+        updated_arg = mock_save_budget_state.call_args[0][0]
+        assert updated_arg != fake_balance 
+        assert updated_arg.rent == Decimal("0")
+
+        mock_save_budget_state.assert_called_once_with(updated_arg, mock_cursor)
+        mock_update_monthly_event.assert_called_once_with(fake_id, fake_today)

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,5 +1,5 @@
 from budgetpet.infrastructure import get_monthly_events
-from budgetpet.constants import TRANSACTIONS_LOG_PATH, BUDGET_PATH, EXPENSE_CATEGORY
+from budgetpet.constants import EXPENSE_CATEGORY
 
 def test_print_last_executed_day():
     result = get_monthly_events()


### PR DESCRIPTION
- Fixed incorrect field name ('op_rent' → 'rent') causing rent not to reset
- Added tests to cover rent_pay behavior and prevent regressions